### PR TITLE
Fixed Parameter class not acquiring the correct _type field

### DIFF
--- a/swaggyp/__init__.py
+++ b/swaggyp/__init__.py
@@ -174,7 +174,7 @@ class Parameter(Item):
         _in = obj_dict.pop('_in')
 
         obj_dict['in'] = _in
-        if _in != 'body' and self.cleaned_data.get('type') == None:
+        if _in != 'body' and self.cleaned_data.get('_type') == None:
             raise ValidationException('_type is required if _in is not equal to "body"')
         if _in == 'path':
             obj_dict.pop('allowEmptyValue')


### PR DESCRIPTION
# Changes
In `Parameter` class -> `to_dict` method, it now uses `_type` instead of just `type` field.

# Error
Only a line of code. In `Parameter` class, instead of acquiring `_type` field, it was using just `type` so the `_type` field is not actually being acquired so it throws an error `_type is required if _in is not equal to "body"`